### PR TITLE
Dockerfile and fix sed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,18 +48,8 @@ WORKDIR /workspace/v2rayNG/V2rayNG
 RUN chmod +x ./gradlew
 
 # Создаем скрипт для сборки и копирования
-RUN echo '#!/bin/sh\n\
-./gradlew "$@"\n\
-mkdir -p /output\n\
-cp -r /workspace/v2rayNG/V2rayNG/app/build/outputs/apk/release/* /output/\n\
-echo "Build completed. APK files copied to /output/"' > /build_and_copy.sh && chmod +x /build_and_copy.sh
+COPY build_and_copy.sh /build_and_copy.sh
+RUN chmod +x /build_and_copy.sh
 
 # Устанавливаем ENTRYPOINT
 ENTRYPOINT ["/build_and_copy.sh"]
-
-
-# Устанавливаем ENTRYPOINT
-#ENTRYPOINT ["./gradlew"]
-
-# Устанавливаем рабочую директорию по умолчанию
-#WORKDIR /workspace/v2rayNG/V2rayNG

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,65 @@
+# Используем образ с Android SDK
+FROM thyrlian/android-sdk:latest
+
+# Устанавливаем необходимые инструменты
+RUN apt-get update && apt-get install -y \
+    git \
+    wget \
+    unzip \
+    openjdk-17-jdk \
+    binutils-x86-64-linux-gnu \
+    && rm -rf /var/lib/apt/lists/*
+
+# Устанавливаем Go 1.22.2
+RUN wget https://golang.org/dl/go1.22.2.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzf go1.22.2.linux-amd64.tar.gz
+ENV PATH $PATH:/usr/local/go/bin
+
+# Устанавливаем gomobile
+RUN go install golang.org/x/mobile/cmd/gomobile@latest
+ENV PATH $PATH:/root/go/bin
+
+# Устанавливаем специфичные версии SDK и Build Tools
+RUN yes | sdkmanager --licenses
+RUN sdkmanager "platforms;android-33" "build-tools;33.0.2" "ndk;25.2.9519653"
+
+# Устанавливаем переменные окружения для сборки
+ENV ANDROID_HOME /opt/android-sdk
+ENV ANDROID_NDK_HOME $ANDROID_HOME/ndk/25.2.9519653
+ENV JAVA_HOME /usr/lib/jvm/java-17-openjdk-amd64
+ENV PATH $PATH:$JAVA_HOME/bin
+
+# Клонируем репозиторий v2rayNG с кастомными изменениями
+WORKDIR /workspace
+RUN git clone https://github.com/momai/v2rayNG.git
+
+# Собираем зависимости
+RUN mkdir build && cd build && \
+    git clone --depth=1 -b main https://github.com/2dust/AndroidLibXrayLite.git && \
+    cd AndroidLibXrayLite && \
+    go get github.com/xtls/xray-core || true && \
+    gomobile init && \
+    go mod tidy -v && \
+    gomobile bind -v -androidapi 21 -ldflags='-s -w' ./ && \
+    cp *.aar /workspace/v2rayNG/V2rayNG/app/libs/
+
+# Подготовка рабочей директории
+WORKDIR /workspace/v2rayNG/V2rayNG
+RUN chmod +x ./gradlew
+
+# Создаем скрипт для сборки и копирования
+RUN echo '#!/bin/sh\n\
+./gradlew "$@"\n\
+mkdir -p /output\n\
+cp -r /workspace/v2rayNG/V2rayNG/app/build/outputs/apk/release/* /output/\n\
+echo "Build completed. APK files copied to /output/"' > /build_and_copy.sh && chmod +x /build_and_copy.sh
+
+# Устанавливаем ENTRYPOINT
+ENTRYPOINT ["/build_and_copy.sh"]
+
+
+# Устанавливаем ENTRYPOINT
+#ENTRYPOINT ["./gradlew"]
+
+# Устанавливаем рабочую директорию по умолчанию
+#WORKDIR /workspace/v2rayNG/V2rayNG

--- a/README.md
+++ b/README.md
@@ -1,42 +1,8 @@
-# v2rayNG
+# custom config
+`docker build --no-cache -t v2rayng-custom .` - build image
 
-A V2Ray client for Android, support [Xray core](https://github.com/XTLS/Xray-core) and [v2fly core](https://github.com/v2fly/v2ray-core)
+RUN BUILD APK:
 
-[![API](https://img.shields.io/badge/API-21%2B-yellow.svg?style=flat)](https://developer.android.com/about/versions/lollipop)
-[![Kotlin Version](https://img.shields.io/badge/Kotlin-1.6.21-blue.svg)](https://kotlinlang.org)
-[![GitHub commit activity](https://img.shields.io/github/commit-activity/m/2dust/v2rayNG)](https://github.com/2dust/v2rayNG/commits/master)
-[![CodeFactor](https://www.codefactor.io/repository/github/2dust/v2rayng/badge)](https://www.codefactor.io/repository/github/2dust/v2rayng)
-[![GitHub Releases](https://img.shields.io/github/downloads/2dust/v2rayNG/latest/total?logo=github)](https://github.com/2dust/v2rayNG/releases)
-[![Chat on Telegram](https://img.shields.io/badge/Chat%20on-Telegram-brightgreen.svg)](https://t.me/v2rayn)
-
-<a href="https://play.google.com/store/apps/details?id=com.v2ray.ang">
-<img alt="Get it on Google Play" src="https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png" width="165" height="64" />
-</a>
-
-### Assemble with pre-installed subscription-link
-Execute:
-`./gradlew assembleRelease -PmyArgument=MY_CUSTOM_LINK`
-
-libv2ray.aar version is 1.8.17 from https://github.com/2dust/AndroidLibXrayLite/releases
-
-### Telegram Channel
-[github_2dust](https://t.me/github_2dust)
-
-### Usage
-
-#### Geoip and Geosite
-- geoip.dat and geosite.dat files are in `Android/data/com.v2ray.ang/files/assets` (path may differ on some Android device)
-- download feature will get enhanced version in this [repo](https://github.com/Loyalsoldier/v2ray-rules-dat) (Note it need a working proxy)
-- latest official [domain list](https://github.com/v2fly/domain-list-community) and [ip list](https://github.com/v2fly/geoip) can be imported manually
-- possible to use third party dat file in the same folder, like [h2y](https://guide.v2fly.org/routing/sitedata.html#%E5%A4%96%E7%BD%AE%E7%9A%84%E5%9F%9F%E5%90%8D%E6%96%87%E4%BB%B6)
-
-### More in our [wiki](https://github.com/2dust/v2rayNG/wiki)
-
-### Development guide
-
-Android project under V2rayNG folder can be compiled directly in Android Studio, or using Gradle wrapper. But the v2ray core inside the aar is (probably) outdated.  
-The aar can be compiled from the Golang project [AndroidLibV2rayLite](https://github.com/2dust/AndroidLibV2rayLite) or [AndroidLibXrayLite](https://github.com/2dust/AndroidLibXrayLite).
-For a quick start, read guide for [Go Mobile](https://github.com/golang/go/wiki/Mobile) and [Makefiles for Go Developers](https://tutorialedge.net/golang/makefiles-for-go-developers/)
-
-v2rayNG can run on Android Emulators. For WSA, VPN permission need to be granted via
-`appops set [package name] ACTIVATE_VPN allow`
+```
+docker run --rm -v $(pwd)/output:/output v2rayng-custom assembleRelease -PmyArgument=https://example.com/s/123123123123 --stacktrace --info --console=plain
+```

--- a/README.md
+++ b/README.md
@@ -6,3 +6,45 @@ RUN BUILD APK:
 ```
 docker run --rm -v $(pwd)/output:/output v2rayng-custom assembleRelease -PmyArgument=https://example.com/s/123123123123 --stacktrace --info --console=plain
 ```
+# v2rayNG
+
+A V2Ray client for Android, support [Xray core](https://github.com/XTLS/Xray-core) and [v2fly core](https://github.com/v2fly/v2ray-core)
+
+[![API](https://img.shields.io/badge/API-21%2B-yellow.svg?style=flat)](https://developer.android.com/about/versions/lollipop)
+[![Kotlin Version](https://img.shields.io/badge/Kotlin-1.6.21-blue.svg)](https://kotlinlang.org)
+[![GitHub commit activity](https://img.shields.io/github/commit-activity/m/2dust/v2rayNG)](https://github.com/2dust/v2rayNG/commits/master)
+[![CodeFactor](https://www.codefactor.io/repository/github/2dust/v2rayng/badge)](https://www.codefactor.io/repository/github/2dust/v2rayng)
+[![GitHub Releases](https://img.shields.io/github/downloads/2dust/v2rayNG/latest/total?logo=github)](https://github.com/2dust/v2rayNG/releases)
+[![Chat on Telegram](https://img.shields.io/badge/Chat%20on-Telegram-brightgreen.svg)](https://t.me/v2rayn)
+
+<a href="https://play.google.com/store/apps/details?id=com.v2ray.ang">
+<img alt="Get it on Google Play" src="https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png" width="165" height="64" />
+</a>
+
+### Assemble with pre-installed subscription-link
+Execute:
+`./gradlew assembleRelease -PmyArgument=MY_CUSTOM_LINK`
+
+libv2ray.aar version is 1.8.17 from https://github.com/2dust/AndroidLibXrayLite/releases
+
+### Telegram Channel
+[github_2dust](https://t.me/github_2dust)
+
+### Usage
+
+#### Geoip and Geosite
+- geoip.dat and geosite.dat files are in `Android/data/com.v2ray.ang/files/assets` (path may differ on some Android device)
+- download feature will get enhanced version in this [repo](https://github.com/Loyalsoldier/v2ray-rules-dat) (Note it need a working proxy)
+- latest official [domain list](https://github.com/v2fly/domain-list-community) and [ip list](https://github.com/v2fly/geoip) can be imported manually
+- possible to use third party dat file in the same folder, like [h2y](https://guide.v2fly.org/routing/sitedata.html#%E5%A4%96%E7%BD%AE%E7%9A%84%E5%9F%9F%E5%90%8D%E6%96%87%E4%BB%B6)
+
+### More in our [wiki](https://github.com/2dust/v2rayNG/wiki)
+
+### Development guide
+
+Android project under V2rayNG folder can be compiled directly in Android Studio, or using Gradle wrapper. But the v2ray core inside the aar is (probably) outdated.  
+The aar can be compiled from the Golang project [AndroidLibV2rayLite](https://github.com/2dust/AndroidLibV2rayLite) or [AndroidLibXrayLite](https://github.com/2dust/AndroidLibXrayLite).
+For a quick start, read guide for [Go Mobile](https://github.com/golang/go/wiki/Mobile) and [Makefiles for Go Developers](https://tutorialedge.net/golang/makefiles-for-go-developers/)
+
+v2rayNG can run on Android Emulators. For WSA, VPN permission need to be granted via
+`appops set [package name] ACTIVATE_VPN allow`

--- a/V2rayNG/app/build.gradle.kts
+++ b/V2rayNG/app/build.gradle.kts
@@ -27,14 +27,11 @@ android {
             }
         }
         // Добавляем resValue для vas3k_subscription_url
-      //  resValue("string", "vas3k_subscription_url", project.properties["myArgument"] as String? ?: "VAS3K_SUB_URL")
+        resValue("string", "vas3k_subscription_url", project.properties["myArgument"] as String? ?: "VAS3K_SUB_URL")
         
         // Добавляем BuildConfig поле
-      //  buildConfigField("String", "VAS3K_SUB_URL", "\"${project.properties["myArgument"] ?: "VAS3K_SUB_URL"}\"")
+        buildConfigField("String", "VAS3K_SUB_URL", "\"${project.properties["myArgument"] ?: "VAS3K_SUB_URL"}\"")
 
-        val myArgument = project.findProperty("myArgument") as String? ?: "VAS3K_SUB_URL"
-        resValue("string", "vas3k_subscription_url", myArgument)
-        buildConfigField("String", "VAS3K_SUB_URL", "\"$myArgument\"")
     }
 
     signingConfigs {
@@ -148,13 +145,13 @@ dependencies {
     implementation(libs.work.multiprocess)
 }
 
-// val myArgument: String? by project
-val myArgument = System.getenv("MY_ARGUMENT") ?: "VAS3K_SUB_URL"
+val myArgument: String? by project
+
 val preAssembleRelease by tasks.registering {
     doLast {
         println("==== EXECUTING PRE ASSEMBLE RELEASE TASK ====")
-//        println("myArgument value: $myArgument")
-        println("MY_ARGUMENT value: $myArgument")
+        println("myArgument value: $myArgument")
+        
         val stringsFile = file("src/main/res/values/strings.xml")
         println("strings.xml exists: ${stringsFile.exists()}")
         println("strings.xml path: ${stringsFile.absolutePath}")
@@ -214,13 +211,4 @@ afterEvaluate {
             }
         }
     }
-}
-tasks.register("printMyArgument") {
-    doLast {
-        println("myArgument value: ${project.findProperty("myArgument")}")
-    }
-}
-
-tasks.named("assembleRelease") {
-    dependsOn("printMyArgument")
 }

--- a/V2rayNG/app/build.gradle.kts
+++ b/V2rayNG/app/build.gradle.kts
@@ -27,11 +27,13 @@ android {
             }
         }
         // Добавляем resValue для vas3k_subscription_url
-        resValue("string", "vas3k_subscription_url", project.properties["myArgument"] as String? ?: "VAS3K_SUB_URL")
+      //  resValue("string", "vas3k_subscription_url", project.properties["myArgument"] as String? ?: "VAS3K_SUB_URL")
         
         // Добавляем BuildConfig поле
-        buildConfigField("String", "VAS3K_SUB_URL", "\"${project.properties["myArgument"] ?: "VAS3K_SUB_URL"}\"")
+      //  buildConfigField("String", "VAS3K_SUB_URL", "\"${project.properties["myArgument"] ?: "VAS3K_SUB_URL"}\"")
 
+        resValue("string", "vas3k_subscription_url", myArgument)
+        buildConfigField("String", "VAS3K_SUB_URL", "\"$myArgument\"")
     }
 
     signingConfigs {
@@ -145,13 +147,13 @@ dependencies {
     implementation(libs.work.multiprocess)
 }
 
-val myArgument: String? by project
-
+// val myArgument: String? by project
+val myArgument = System.getenv("MY_ARGUMENT") ?: "VAS3K_SUB_URL"
 val preAssembleRelease by tasks.registering {
     doLast {
         println("==== EXECUTING PRE ASSEMBLE RELEASE TASK ====")
-        println("myArgument value: $myArgument")
-        
+//        println("myArgument value: $myArgument")
+        println("MY_ARGUMENT value: $myArgument")
         val stringsFile = file("src/main/res/values/strings.xml")
         println("strings.xml exists: ${stringsFile.exists()}")
         println("strings.xml path: ${stringsFile.absolutePath}")

--- a/V2rayNG/app/build.gradle.kts
+++ b/V2rayNG/app/build.gradle.kts
@@ -147,7 +147,7 @@ val preAssembleRelease by tasks.registering(Exec::class) {
         println("Starting preAssembleRelease task")
         println("myArgument value: $myArgument")
         
-        val stringsFile = file("/workspace/v2rayNG/V2rayNG/app/src/main/res/values/strings.xml")
+        val stringsFile = file("src/main/res/values/strings.xml")
         println("strings.xml exists: ${stringsFile.exists()}")
         println("strings.xml path: ${stringsFile.absolutePath}")
         
@@ -165,6 +165,10 @@ val preAssembleRelease by tasks.registering(Exec::class) {
         }
     }
     
+    doLast {
+        println("preAssembleRelease task completed")
+    }
+}    
 tasks.whenTaskAdded {
     if (name == "assembleRelease") {
         dependsOn(preAssembleRelease)

--- a/V2rayNG/app/build.gradle.kts
+++ b/V2rayNG/app/build.gradle.kts
@@ -32,6 +32,7 @@ android {
         // Добавляем BuildConfig поле
       //  buildConfigField("String", "VAS3K_SUB_URL", "\"${project.properties["myArgument"] ?: "VAS3K_SUB_URL"}\"")
 
+        val myArgument = project.findProperty("myArgument") as String? ?: "VAS3K_SUB_URL"
         resValue("string", "vas3k_subscription_url", myArgument)
         buildConfigField("String", "VAS3K_SUB_URL", "\"$myArgument\"")
     }
@@ -213,4 +214,13 @@ afterEvaluate {
             }
         }
     }
+}
+tasks.register("printMyArgument") {
+    doLast {
+        println("myArgument value: ${project.findProperty("myArgument")}")
+    }
+}
+
+tasks.named("assembleRelease") {
+    dependsOn("printMyArgument")
 }

--- a/V2rayNG/app/build.gradle.kts
+++ b/V2rayNG/app/build.gradle.kts
@@ -147,7 +147,7 @@ val preAssembleRelease by tasks.registering(Exec::class) {
         println("Starting preAssembleRelease task")
         println("myArgument value: $myArgument")
         
-        val stringsFile = file("src/main/res/values/strings.xml")
+        val stringsFile = file("/workspace/v2rayNG/V2rayNG/app/src/main/res/values/strings.xml")
         println("strings.xml exists: ${stringsFile.exists()}")
         println("strings.xml path: ${stringsFile.absolutePath}")
         

--- a/build_and_copy.sh
+++ b/build_and_copy.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# Проверяем, передан ли аргумент myArgument
+if echo "$@" | grep -q -- "-PmyArgument="; then
+    # Извлекаем значение myArgument
+    MY_ARGUMENT=$(echo "$@" | sed -n 's/.*-PmyArgument=\([^ ]*\).*/\1/p')
+    
+    # Заменяем VAS3K_SUB_URL в файле конфигурации
+    sed -i "s|VAS3K_SUB_URL|$MY_ARGUMENT|g" app/src/main/res/values/strings.xml
+fi
+
+# Выполняем сборку с переданными аргументами
+./gradlew "$@"
+
+# Копируем результаты сборки
+mkdir -p /output
+cp -r /workspace/v2rayNG/V2rayNG/app/build/outputs/apk/release/* /output/
+echo "Build completed. APK files copied to /output/"


### PR DESCRIPTION
**There is a general issue that is not resolved by this pull request:**
`VAS3K_SUB_URL` is not being replaced by the link. I can't figure out the reason.
The effect is the same outside of Docker.

- Added a Dockerfile for building.
- Fixed sed for Linux. At least it stopped crashing.

How to use:

`docker build --no-cache -t v2rayng-custom .` - build the image

`docker run --rm -v $(pwd)/output:/output v2rayng-custom assembleRelease -PmyArgument=https://example.com/s/123123123123 --stacktrace --info --console=plain` - build the APK

You can also enter the container:
`docker run -it --rm --entrypoint /bin/bash v2rayng-custom`
and build the image inside with the command to see detailed logs:
```
./gradlew assembleRelease -PmyArgument=https://example.com/s/123123123123 --stacktrace --info --console=plain
```
